### PR TITLE
Insert environment with completion

### DIFF
--- a/org-auctex-keys.el
+++ b/org-auctex-keys.el
@@ -4,7 +4,7 @@
 
 ;; Author: Fabrice Niessen <(concat "fniessen" at-sign "pirilampo.org")>
 ;; URL: https://github.com/fniessen/org-auctex-key-bindings
-;; Version: 20130929.2030
+;; Version: 20131001.1516
 ;; Keywords: org mode, latex, auctex, key bindings, shortcuts, emulation
 
 ;; This file is NOT part of GNU Emacs.
@@ -146,11 +146,33 @@ to use, as specified by `org-auckeys-font-list'."
            (save-excursion
              (insert after))))))
 
-(defun org-auckeys-environment (env)
-  "Insert environment syntax at point."
-  (interactive "sEnvironment: ")
-  (insert (format "#+begin_%s\n\n#+end_%s\n" env env))
-  (forward-line -2))
+(defun org-auckeys-completing-read (prompt choices &optional printfun &rest other)
+  "CHOICES can be a list of any lisp objects. PRINTFUN is used to
+show them in the minibuffer prompt -- by default this is
+`prin1-to-string'."
+  (let ((printfun (or printfun #'prin1-to-string))
+        (choices (mapcar
+                  (lambda (choice)
+                    (cons (funcall printfun choice) choice))
+                  choices)))
+    (cdr
+     (assoc
+      (apply #'completing-read prompt (mapcar #'car choices) other)
+      choices))))
+
+(defun org-auckeys-environment (template)
+  "Insert TEMPLATE at point. Interactively, TEMPLATE is an
+element from `org-structure-template-alist'"
+  (interactive (list
+                (completing-read-with-printfun
+                 "Environment: "
+                 org-structure-template-alist
+                 (lambda (cell)
+                   (let ((template (cadr cell)))
+                     (if (string-match "\\`[^ \n]+" template)
+                         (match-string 0 template)
+                       template))))))
+  (org-complete-expand-structure-template (point) template))
 
 ;;---------------------------------------------------------------------------
 ;; that's it


### PR DESCRIPTION
Hi Fabrice. I suggest to modify org-auckeys-environment to use org-structure-template-alist as a source for completing the name of the environment. PR is how I implemented it for myself ; feel free to use it or not.
